### PR TITLE
Konflux Onboarding Prerequisites

### DIFF
--- a/.konflux/Containerfile
+++ b/.konflux/Containerfile
@@ -1,0 +1,33 @@
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.20-2.1721752936 as builder
+
+# Jenkins .war requires git to be present for the build.
+USER root
+RUN microdnf install -y git
+
+USER 185
+
+# plugin-management-cli contains the .jar files we want
+ENV MAVEN_S2I_ARTIFACT_DIRS="plugin-management-cli/target" \
+    MAVEN_S2I_GOALS="clean install" \
+    S2I_SOURCE_DEPLOYMENTS_FILTER="*.jar"
+
+# Copying in source code. Red Hat OpenJDK S2I buiders expect source content in /tmp/src by default
+COPY --chown=185:0 . /tmp/src
+
+RUN /usr/local/s2i/assemble
+
+# Use slimmer runtime image for deploying Jenkins
+FROM registry.redhat.io/ubi9/openjdk-21-runtime:1.20-2.1721752928
+
+USER 185
+COPY --from=builder --chown=185:0 /deployments/jenkins-plugin-manager-*.jar /deployments/jenkins-plugin-manager.jar
+# JAVA_APP_JAR instructs the image run script to use the jar file as its main class.
+ENV JAVA_APP_JAR="jenkins-plugin-manager.jar"
+
+LABEL com.redhat.component="redhat-openshift-jenkins-plugin-manager-container" \
+      description="Jenkins plugin manager runner container image." \
+      io.k8s.description="Jenkins plugin manager container image." \
+      io.k8s.display-name="Jenkins Plugin Manager" \
+      io.openshift.tags="jenkins,jenkins2,ci,cicd" \
+      name="ocp-tools-4/openshift-jenkins-plugin-manager-rhel9" \
+      summary="Jenkins Plugin Manager for RHEL 9."


### PR DESCRIPTION
Add a Containerfile which packages the plugin manager into a container image. The plugin manager is intended to be used as a utility within the main Jenkins container image. This Containerfile packages the plugin manager .jar into a runnable image for testing purposes. The image also makes it simple to extract the plugin manager .jar by placing it in a well-known location
(`/deployments/jenkins-plugin-manager.jar`)